### PR TITLE
Update NuGet.Config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="Cli-Deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="AspNetCI" value="https://www.myget.org/F/aspnetcirelease/api/v3/index.json" />
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
Added an additional feed "https://dotnet.myget.org/F/cli-deps/api/v3/index.json" to fetch latest packages from the cli repository. Cannot `dotnet restore` on HelloWebApi sample without it. The version of the dotnet cli used is 1.0.0-rc2-002392.

Fixes #43