### PR TITLE
Update launch.json for C# Extension 1.3

### DIFF
--- a/HelloMvc/.vscode/launch.json
+++ b/HelloMvc/.vscode/launch.json
@@ -2,16 +2,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceRoot}/bin/Debug/netcoreapp1.0/HelloMvc.dll",
-            "args": [],
-            "cwd": "${workspaceRoot}",
-            "stopAtEntry": false
-        },
-        {
             "name": ".NET Core Launch (web)",
             "type": "coreclr",
             "request": "launch",
@@ -33,13 +23,19 @@
                 "linux": {
                     "command": "xdg-open"
                 }
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceRoot}/Views"
             }
         },
         {
             "name": ".NET Core Attach",
             "type": "coreclr",
             "request": "attach",
-            "processName": "<example>"
+            "processId": "${command.pickProcess}"
         }
     ]
 }

--- a/HelloMvcApi/.vscode/launch.json
+++ b/HelloMvcApi/.vscode/launch.json
@@ -2,16 +2,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceRoot}/bin/Debug/netcoreapp1.0/HelloMvcApi.dll",
-            "args": [],
-            "cwd": "${workspaceRoot}",
-            "stopAtEntry": false
-        },
-        {
             "name": ".NET Core Launch (web)",
             "type": "coreclr",
             "request": "launch",
@@ -22,10 +12,10 @@
             "stopAtEntry": false,
             "launchBrowser": {
                 "enabled": true,
-                "args": "${auto-detect-url}",
+                "args": "${auto-detect-url}/api/products",
                 "windows": {
                     "command": "cmd.exe",
-                    "args": "/C start ${auto-detect-url}"
+                    "args": "/C start ${auto-detect-url}/api/products"
                 },
                 "osx": {
                     "command": "open"
@@ -33,13 +23,19 @@
                 "linux": {
                     "command": "xdg-open"
                 }
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceRoot}/Views"
             }
         },
         {
             "name": ".NET Core Attach",
             "type": "coreclr",
             "request": "attach",
-            "processName": "<example>"
+            "processId": "${command.pickProcess}"
         }
     ]
 }

--- a/HelloWeb/.vscode/launch.json
+++ b/HelloWeb/.vscode/launch.json
@@ -2,16 +2,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceRoot}/bin/Debug/netcoreapp1.0/HelloWeb.dll",
-            "args": [],
-            "cwd": "${workspaceRoot}",
-            "stopAtEntry": false
-        },
-        {
             "name": ".NET Core Launch (web)",
             "type": "coreclr",
             "request": "launch",
@@ -33,13 +23,19 @@
                 "linux": {
                     "command": "xdg-open"
                 }
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceRoot}/Views"
             }
         },
         {
             "name": ".NET Core Attach",
             "type": "coreclr",
             "request": "attach",
-            "processName": "<example>"
+            "processId": "${command.pickProcess}"
         }
     ]
 }


### PR DESCRIPTION
The 1.3 version of the C# extension adds support for .cshtml debugging and an attach dialog, but requires changes to the launch.json file. This updates the sample to match the new generated launch.json.

The 1.3 version should be in the marketplace within a few hours. I will leave a comment once it is ready.